### PR TITLE
Change implementation to use tests as saving point so that we can sav…

### DIFF
--- a/src/MiniCover/HitServices/HitService.cs
+++ b/src/MiniCover/HitServices/HitService.cs
@@ -1,65 +1,30 @@
 ﻿using MiniCover.Utils;
-using System;
-using System.Collections.Concurrent;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading;
 
 namespace MiniCover
 {
     public static class HitService
     {
-        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<int, Hit>> files = new ConcurrentDictionary<string, ConcurrentDictionary<int, Hit>>();
-
-        public static void Init(string fileName)
-        {
-            files.GetOrAdd(fileName, (f) => new ConcurrentDictionary<int, Hit>());
-        }
-
         public static MethodContext EnterMethod(string fileName)
         {
-            var file = files.GetOrAdd(fileName, f => new ConcurrentDictionary<int, Hit>());
-
-            return new MethodContext(file);
-        }
-
-        static void Save()
-        {
-            foreach (var file in files)
-            {
-                using (var fileStream = File.Open(file.Key, FileMode.Append, FileAccess.Write, FileShare.None))
-                using (var streamWriter = new StreamWriter(fileStream))
-                {
-                    if (fileStream.Position != 0) streamWriter.Write(",");
-                    var json = Newtonsoft.Json.JsonConvert.SerializeObject(file.Value.Select(a => a.Value));
-                    json = json.Substring(1, json.Length - 2);
-                    streamWriter.Write(json);
-                    streamWriter.Flush();
-                }
-            }
-        }
-
-        static HitService()
-        {
-            AppDomain.CurrentDomain.ProcessExit += (sender, args) => Save();
+            return new MethodContext(fileName);
         }
 
         public class MethodContext
         {
-            private static readonly AsyncLocal<MethodBase> TestMethodCache = new AsyncLocal<MethodBase>();
-
-            private readonly ConcurrentDictionary<int, Hit> hitInstructions;
-            private readonly MethodBase testMethod;
+            private readonly string filePath;
+            private static readonly AsyncLocal<HitTestMethod> TestMethodCache = new AsyncLocal<HitTestMethod>();
+            
+            private readonly HitTestMethod testMethod;
             private readonly bool clearTestMethodCache;
 
-            public MethodContext(ConcurrentDictionary<int, Hit> hitInstructions)
+            public MethodContext(string filePath)
             {
-                this.hitInstructions = hitInstructions;
-
+                this.filePath = filePath;
                 if (TestMethodCache.Value == null)
                 {
-                    TestMethodCache.Value = TestMethodUtils.GetTestMethod();
+                    TestMethodCache.Value = new HitTestMethod(TestMethodUtils.GetTestMethod());
                     clearTestMethodCache = true;
                 }
 
@@ -68,14 +33,29 @@ namespace MiniCover
 
             public void HitInstruction(int id)
             {
-                var hitInstruction = hitInstructions.GetOrAdd(id, i => new Hit(i));
-                hitInstruction.HitedBy(testMethod);
+                testMethod.HasHit(id);
+
             }
 
             public void Exit()
             {
                 if (clearTestMethodCache)
+                {
+                    this.Save();
                     TestMethodCache.Value = null;
+                }
+            }
+
+            private void Save()
+            {
+                using (var fileStream = File.Open(this.filePath, FileMode.Append, FileAccess.Write, FileShare.None))
+                using (var streamWriter = new StreamWriter(fileStream))
+                {
+                    if (fileStream.Position != 0) streamWriter.Write(",");
+                    var json = Newtonsoft.Json.JsonConvert.SerializeObject(testMethod);
+                    streamWriter.Write(json);
+                    streamWriter.Flush();
+                }
             }
         }
     }

--- a/src/MiniCover/HitServices/Hits.cs
+++ b/src/MiniCover/HitServices/Hits.cs
@@ -37,18 +37,18 @@ namespace MiniCover
 
         public static Hits TryReadFromFile(string file)
         {
-            var hits = ReadHitsFromFile(file).ToArray();
+            if (!File.Exists(file))
+                return new Hits(Enumerable.Empty<Hit>());
+            var json = File.ReadAllText(file);
 
-            return new Hits(hits);
+            return ConvertToHits($"[{json}]");
         }
 
-        private static IEnumerable<Hit> ReadHitsFromFile(string file)
+        public static Hits ConvertToHits(string json)
         {
-            if (!File.Exists(file))
-                return Enumerable.Empty<Hit>();
-
-            var json = File.ReadAllText(file);
-            return JsonConvert.DeserializeObject<Hit[]>($"[{json}]");
+            var notMergedHits = JsonConvert.DeserializeObject<HitTestMethod[]>(json)
+                .SelectMany(method => method.HitedInstructions.Select(id => new Hit(id.Key, id.Value, new[] {method}))).ToArray();
+            return new Hits(notMergedHits);
         }
     }
 }

--- a/src/MiniCover/Instrumentation/Instrumenter.cs
+++ b/src/MiniCover/Instrumentation/Instrumenter.cs
@@ -152,7 +152,7 @@ namespace MiniCover.Instrumentation
                 var instrumentedAttributeReference = assemblyDefinition.MainModule.ImportReference(instrumentedAttributeConstructor);
                 assemblyDefinition.CustomAttributes.Add(new CustomAttribute(instrumentedAttributeReference));
 
-                CreateAssemblyInit(assemblyDefinition);
+                //CreateAssemblyInit(assemblyDefinition);
 
                 var enterMethodInfo = hitServiceType.GetMethod("EnterMethod");
                 var exitMethodInfo = methodContextType.GetMethod("Exit");
@@ -304,25 +304,7 @@ namespace MiniCover.Instrumentation
                 File.Delete(pdbBackupFile);
             }
         }
-
-        private void CreateAssemblyInit(AssemblyDefinition assemblyDefinition)
-        {
-            var initMethodInfo = this.hitServiceType.GetMethod("Init");
-            var initMethodReference = assemblyDefinition.MainModule.ImportReference(initMethodInfo);
-            var moduleType = assemblyDefinition.MainModule.GetType("<Module>");
-            var moduleConstructor = moduleType.FindOrCreateCctor();
-            var ilProcessor = moduleConstructor.Body.GetILProcessor();
-
-            var initInstruction = ilProcessor.Create(OpCodes.Call, initMethodReference);
-            if (moduleConstructor.Body.Instructions.Count > 0)
-                ilProcessor.InsertBefore(moduleConstructor.Body.Instructions[0], initInstruction);
-            else
-                ilProcessor.Append(initInstruction);
-
-            var pathParamLoadInstruction = ilProcessor.Create(OpCodes.Ldstr, hitsFile);
-            ilProcessor.InsertBefore(initInstruction, pathParamLoadInstruction);
-        }
-
+        
         private void InstrumentInstruction(int instructionId, Instruction instruction,
             MethodReference hitInstructionReference, MethodDefinition method, ILProcessor ilProcessor,
             VariableDefinition methodContextVariable)

--- a/src/MiniCover/Instrumentation/Instrumenter.cs
+++ b/src/MiniCover/Instrumentation/Instrumenter.cs
@@ -152,8 +152,6 @@ namespace MiniCover.Instrumentation
                 var instrumentedAttributeReference = assemblyDefinition.MainModule.ImportReference(instrumentedAttributeConstructor);
                 assemblyDefinition.CustomAttributes.Add(new CustomAttribute(instrumentedAttributeReference));
 
-                //CreateAssemblyInit(assemblyDefinition);
-
                 var enterMethodInfo = hitServiceType.GetMethod("EnterMethod");
                 var exitMethodInfo = methodContextType.GetMethod("Exit");
                 var hitInstructionMethodInfo = methodContextType.GetMethod("HitInstruction");

--- a/tests/MiniCover.UnitTests/HitServices/HitsTests.cs
+++ b/tests/MiniCover.UnitTests/HitServices/HitsTests.cs
@@ -1,0 +1,101 @@
+﻿using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using Shouldly;
+using Xunit;
+
+namespace MiniCover.UnitTests.HitServices
+{
+    public class HitsTests
+    {
+        [Fact]
+        public void ShouldParseTheHitJsonCorrectly()
+        {
+            var json = @"[
+    {
+        ""AssemblyName"": ""MiniCover.XUnit.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"",
+        ""ClassName"": ""UnitTest1"",
+        ""MethodName"": ""XUnitTest2"",
+        ""AssemblyLocation"": ""C:\\Users\\bhugo_000\\Source\\Repos\\minicover\\test\\MiniCover.XUnit.Tests\\bin\\Debug\\netcoreapp2.0\\MiniCover.XUnit.Tests.dll"",
+        ""Counter"": 12500305,
+        ""HitedInstructions"": {
+            ""17"": 2500000,
+            ""19"": 2500000,
+            ""20"": 50,
+            ""21"": 2500000,
+            ""22"": 2500000,
+            ""23"": 2500050,
+            ""24"": 50,
+            ""33"": 1,
+            ""34"": 1,
+            ""35"": 1,
+            ""37"": 1,
+            ""38"": 50,
+            ""39"": 50,
+            ""40"": 51
+        }
+    },
+    {
+        ""AssemblyName"": ""MiniCover.NUnit.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"",
+        ""ClassName"": ""UnitTest1"",
+        ""MethodName"": ""NUnitTest2"",
+        ""AssemblyLocation"": ""C:\\Users\\bhugo_000\\Source\\Repos\\minicover\\test\\MiniCover.NUnit.Tests\\bin\\Debug\\netcoreapp2.0\\MiniCover.NUnit.Tests.dll"",
+        ""Counter"": 12500305,
+        ""HitedInstructions"": {
+            ""9"": 1,
+            ""10"": 1,
+            ""11"": 1,
+            ""13"": 1,
+            ""14"": 50,
+            ""15"": 50,
+            ""16"": 51,
+            ""17"": 2500000,
+            ""19"": 2500000,
+            ""20"": 50,
+            ""21"": 2500000,
+            ""22"": 2500000,
+            ""23"": 2500050,
+            ""24"": 50
+        }
+    }
+]";
+
+            var hits = Hits.ConvertToHits(json);
+
+            hits.GetInstructionHitCount(17).ShouldBe(5000000);
+            hits.GetInstructionTestMethods(17).Count().ShouldBe(2);
+            hits.GetInstructionTestMethods(17).First().Counter.ShouldBe(2500000);
+        }
+
+        [Fact]
+        public void ShouldMergeTests()
+        {
+            var json = @"[{
+        ""AssemblyName"": ""MiniCover.XUnit.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"",
+        ""ClassName"": ""UnitTest1"",
+        ""MethodName"": ""XUnitTest2"",
+        ""AssemblyLocation"": ""C:\\Users\\bhugo_000\\Source\\Repos\\minicover\\test\\MiniCover.XUnit.Tests\\bin\\Debug\\netcoreapp2.0\\MiniCover.XUnit.Tests.dll"",
+        ""Counter"": 1,
+        ""HitedInstructions"": {
+            ""8"": 1
+        }
+    },
+    {
+        ""AssemblyName"": ""MiniCover.XUnit.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"",
+        ""ClassName"": ""UnitTest1"",
+        ""MethodName"": ""XUnitTest2"",
+        ""AssemblyLocation"": ""C:\\Users\\bhugo_000\\Source\\Repos\\minicover\\test\\MiniCover.XUnit.Tests\\bin\\Debug\\netcoreapp2.0\\MiniCover.XUnit.Tests.dll"",
+        ""Counter"": 1,
+        ""HitedInstructions"": {
+            ""8"": 1
+        }
+    }]";
+
+            var hits = Hits.ConvertToHits(json);
+            hits.GetInstructionHitCount(8).ShouldBe(2);
+            hits.GetInstructionTestMethods(8).ShouldHaveSingleItem();
+            hits.GetInstructionTestMethods(8).First().Counter.ShouldBe(2);
+        }
+    }
+
+   
+}


### PR DESCRIPTION
…e in coverage-hits.txt after each test (if the tests are not instrumented there will be a bigger file)